### PR TITLE
LokiConfigOptions properties are not required

### DIFF
--- a/types/lokijs/index.d.ts
+++ b/types/lokijs/index.d.ts
@@ -152,16 +152,16 @@ interface LokiConstructorOptions {
 
 
 interface LokiConfigOptions {
-    adapter: LokiPersistenceAdapter | null;
-    autoload: boolean;
-    autoloadCallback: (err: any) => void;
-    autosave: boolean;
-    autosaveCallback: (err?: any) => void;
-    autosaveInterval: string | number;
-    persistenceMethod: "fs" | "localStorage" | "memory" | null;
-    destructureDelimiter: string;
-    serializationMethod: "normal" | "pretty" | "destructured" | null;
-    throttledSaves: boolean;
+    adapter?: LokiPersistenceAdapter | null;
+    autoload?: boolean;
+    autoloadCallback?: (err: any) => void;
+    autosave?: boolean;
+    autosaveCallback?: (err?: any) => void;
+    autosaveInterval?: string | number;
+    persistenceMethod?: "fs" | "localStorage" | "memory" | null;
+    destructureDelimiter?: string;
+    serializationMethod?: "normal" | "pretty" | "destructured" | null;
+    throttledSaves?: boolean;
 }
 
 


### PR DESCRIPTION
LokiConfigOptions interface properties are not required, they are optional. Caught the error when using it. If you use this interface it will give you an error that all properties have to be filled which is not true. The LokiJS library already initialize those values. 

Please fill in this template.

- [  ¯\(°_o)/¯  ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ Didn't ever read it ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [  ¯\(°_o)/¯  ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
[ X ] It is just a common error fix. No need to go up a version. 
